### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,14 @@
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+
 version: 2
 updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "09:00"
-      timezone: Asia/Tokyo
     open-pull-requests-limit: 5
     labels:
       - dependencies
       - dependencies/dependabot
       - dependencies/npm
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: daily
-      time: "09:00"
-      timezone: Asia/Tokyo
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - dependencies/dependabot
-      - dependencies/github-actions


### PR DESCRIPTION
## What this PR does / Why we need it

- Changed update interval from daily to weekly
- Removed GitHub Actions updates

To reduce maintenance costs.

## Which issue(s) this PR fixes

None
