### PR TITLE
Fix indexing error when two same captured values

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,20 +11,18 @@ async function run(): Promise<void> {
     const result = re.exec(text);
 
     if (result) {
-      for (const x of result) {
-        const index = result.indexOf(x);
-
-        if (index === 10) {
+      result.forEach((value, index) => {
+        if (index >= 10) {
           return;
         }
 
         if (index === 0) {
-          core.setOutput('match', x);
-          continue;
+          core.setOutput('match', value);
+          return;
         }
 
-        core.setOutput(`group${index}`, x);
-      }
+        core.setOutput(`group${index}`, value);
+      });
     }
   } catch (error) {
     core.error(error);


### PR DESCRIPTION
## What this PR does / Why we need it

In a context where my text is `99.99.99` and the regex is want to use is `^([0-9]+).([0-9]+).[0-9]+$`.
I except to get following output:
```
::set-output:: match=99.99.99
::set-output:: group1=99
::set-output:: group2=99
```
However, the action returns the following output:
```
::set-output:: match=99.99.99
::set-output:: group1=99
::set-output:: group1=99
```
I guess the problem comes from retrieving the index from a value.
```javascript
const index = result.indexOf(x);
```
In this PR, I replaced this by a `forEach()` on the variable `result` in order to retrieve the exact index corresponding to a value.
