### PR TITLE
Upgrade action and node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -8,7 +8,7 @@ jobs:
   update_labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions-ecosystem/action-size@v2
         id: size

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "12.x"
+          node-version: "16.x"
 
       - run: yarn install
 


### PR DESCRIPTION
## What this PR does / Why we need it

- We are using this action and seeing a warning that some action still use Node v12. Should upgrade Node and action version for stability.

## Which issue(s) this PR fixes

- Upgrade Node version to v16.
- Update core action to latest version.
