### PR TITLE
point action to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ outputs:
   group9:
     description: The 9th captured group.
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: search


### PR DESCRIPTION
## What this PR does / Why we need it
Point action to node20 due to Gh deprecation of node16

## Which issue(s) this PR fixes

Fixes #
